### PR TITLE
[Fix] Fix parsing issue in ErrorDetail (#328)

### DIFF
--- a/databricks-sdk-java/src/main/java/com/databricks/sdk/core/error/ErrorDetail.java
+++ b/databricks-sdk-java/src/main/java/com/databricks/sdk/core/error/ErrorDetail.java
@@ -26,7 +26,7 @@ public class ErrorDetail {
     this.type = type;
     this.reason = reason;
     this.domain = domain;
-    this.metadata = Collections.unmodifiableMap(metadata);
+    this.metadata = metadata != null ? Collections.unmodifiableMap(metadata) : null;
   }
 
   public String getType() {

--- a/databricks-sdk-java/src/test/java/com/databricks/sdk/core/error/ApiErrorBodyDeserializationSuite.java
+++ b/databricks-sdk-java/src/test/java/com/databricks/sdk/core/error/ApiErrorBodyDeserializationSuite.java
@@ -51,4 +51,15 @@ public class ApiErrorBodyDeserializationSuite {
     assertEquals(error.getErrorCode(), "theerrorcode");
     assertEquals(error.getMessage(), "themessage");
   }
+
+  @Test
+  void handleNullMetadataFieldInErrorResponse() throws JsonProcessingException {
+    ObjectMapper mapper = new ObjectMapper();
+    String rawResponse =
+        "{\"error_code\":\"METASTORE_DOES_NOT_EXIST\",\"message\":\"No metastore assigned for the current workspace.\",\"details\":[{\"@type\":\"type.googleapis.com/google.rpc.RequestInfo\",\"request_id\":\"1888e822-f1b5-4996-85eb-0d2b5cc402e6\",\"serving_data\":\"\"}]}";
+    ApiErrorBody error = mapper.readValue(rawResponse, ApiErrorBody.class);
+
+    assertEquals(error.getErrorCode(), "METASTORE_DOES_NOT_EXIST");
+    assertEquals(error.getMessage(), "No metastore assigned for the current workspace.");
+  }
 }


### PR DESCRIPTION
## Issue Description
Exceptions are not deserialized correctly, the message field contains the response JSON and the string 'Cannot construct instance of com.databricks.sdk.core.error.ErrorDetail, problem: Cannot invoke "Object.getClass()" because "m" is null'

## Changes
In ErrorDetails class, i added a null check before the unmodifiableMap is created.

## Tests
Created an unit test in ApiErrorBodyDeserializationSuite.java

## See original commit on mainline fork
https://github.com/databricks/databricks-sdk-java/pull/328/commits/f40ec0fa237887f84f86a4af33eb44259e49642a

https://github.com/databricks/databricks-sdk-java/commit/841b34645d111f436dd5e75cde799630daf9f9d0

